### PR TITLE
develop a new monthly report on orders

### DIFF
--- a/models/mart/mrt_monthly_order_report.sql
+++ b/models/mart/mrt_monthly_order_report.sql
@@ -1,0 +1,43 @@
+WITH monthly_users_recap AS (
+
+
+SELECT DATE_TRUNC(order_date,month) AS order_month,
+COUNT(DISTINCT user_name) AS total_monthly_users
+FROM {{ source('sales_database', 'order')}}
+GROUP BY 1
+ORDER BY total_monthly_users DESC
+
+
+), total_monthly_user_from_jawa_timur AS (
+SELECT DATE_TRUNC(order_date,month) AS order_month,
+COUNT(DISTINCT user.user_name) AS total_monthly_users_from_jawa_timur
+FROM {{ source('sales_database', 'order')}} AS orders
+LEFT JOIN {{ source('sales_database', 'user')}} AS user ON user.user_name = orders.user_name
+WHERE user.customer_state LIKE '%JAWA%TIMUR%'
+GROUP BY order_month
+
+
+), monthly_orders_recap AS (
+
+
+SELECT DATE_TRUNC(order_date,month) AS order_months,
+COUNT(order_id) AS total_monthly_orders
+FROM {{ source('sales_database', 'order')}}
+GROUP BY order_month
+
+
+), shipping_cost AS (
+
+
+SELECT shipping_cost
+FROM sales_database.order_item
+WHERE price > 7000
+)
+SELECT u.order_month,
+COALESCE(u.total_monthly_users,0) AS nb_users_monthly,
+COALESCE(jt.total_monthly_users_from_jawa_timur,0) AS total_monthly_user,
+COALESCE(o.total_monthly_orders,0) AS monthly_order_count
+FROM monthly_users_recap AS u
+LEFT JOIN total_monthly_user_from_jawa_timur AS jt ON jt.order_month = u.order_month
+LEFT JOIN monthly_orders_recap AS o ON o.order_month = u.order_month
+ORDER BY order_month

--- a/models/mart/mrt_monthly_order_report.sql
+++ b/models/mart/mrt_monthly_order_report.sql
@@ -53,7 +53,7 @@ order by order_month
 WITH
     total_monthly_user_from_jawa_timur as (
         select
-            date_trunc(order_date, month) as order_month,
+            date_trunc(order_created_at, month) as order_month,
             count(distinct orders.user_id) as total_monthly_users_from_jawa_timur
         from {{ ref('int_sales_database__order') }} orders
         LEFT JOIN {{ ref('stg_google_sheets__account_manager_region_mapping') }} as mapping ON orders.user_state = mapping.state

--- a/models/mart/mrt_monthly_order_report.sql
+++ b/models/mart/mrt_monthly_order_report.sql
@@ -73,4 +73,5 @@ LEFT JOIN {{ ref('stg_google_sheets__account_manager_region_mapping') }} as mapp
 left join total_monthly_user_from_jawa_timur as jt on jt.order_month = DATE_TRUNC(orders.order_created_at, MONTH)
 GROUP BY reporting_date,
     account_manager,
-    state
+    state,
+    total_monthly_users_from_jawa_timur

--- a/models/mart/mrt_monthly_order_report.sql
+++ b/models/mart/mrt_monthly_order_report.sql
@@ -70,7 +70,7 @@ SELECT DATE_TRUNC(order_created_at, MONTH) AS reporting_date,
     total_monthly_users_from_jawa_timur
 FROM {{ ref('int_sales_database__order') }} AS orders
 LEFT JOIN {{ ref('stg_google_sheets__account_manager_region_mapping') }} as mapping ON orders.user_state = mapping.state
-left join total_monthly_user_from_jawa_timur as jt on jt.order_month = u.order_month
+left join total_monthly_user_from_jawa_timur as jt on jt.order_month = DATE_TRUNC(orders.order_created_at, MONTH)
 GROUP BY reporting_date,
     account_manager,
     state


### PR DESCRIPTION
Cette requête SQL est conçue pour extraire et agrégater des données de différentes tables d'une base de données de vente, en utilisant des sous-requêtes (ou Common Table Expressions - CTE) pour structurer le code et améliorer la lisibilité. Voici une description détaillée de chaque partie de la requête :

La première CTE, monthly_users_recap, groupe les commandes par mois en fonction de la date de commande et compte le nombre d'utilisateurs uniques pour chaque mois. Elle utilise la fonction DATE_TRUNC pour tronquer la date de commande au niveau du mois.
La deuxième CTE, total_monthly_user_from_jawa_timur, fait de même que la première mais filtre les utilisateurs dont l'état client contient 'JAWA' et 'TIMUR'.
La troisième CTE, monthly_orders_recap, groupe également les commandes par mois en fonction de la date de commande et compte le nombre total de commandes pour chaque mois.
La quatrième CTE, shipping_cost, sélectionne le coût d'expédition à partir de la table order_item pour les commandes dont le prix est supérieur à 7000.
La requête principale utilise des jointures externes (LEFT JOIN) pour combiner les données des différentes CTE en fonction de la colonne order_month. Elle combine ensuite les résultats des trois premières CTE et utilise la fonction COALESCE pour remplacer les valeurs nulles par zéro. Le résultat final est un tableau qui affiche le mois, le nombre d'utilisateurs mensuels totaux, le nombre d'utilisateurs mensuels totaux pour la région de Jawa Timur, et le nombre total de commandes mensuelles.

En résumé, cette requête SQL permet d'extraire et d'agréger des données de vente en fonction du temps et de la géolocalisation.